### PR TITLE
Comment button now sends one comment at a time

### DIFF
--- a/client/src/components/Posts/Post/Post.js
+++ b/client/src/components/Posts/Post/Post.js
@@ -71,6 +71,7 @@ const Post = ({ post, setCurrentId, fromProfile }) => {
   const [openDeleteComment, setOpenDeleteComment] = useState(false); // for users
   const [openDeleteCommentAdmin, setOpenDeleteCommentAdmin] = useState(false); // for admin
   const [commentID, setCommentID] = useState('');
+  const [commented, setCommented] = useState(false);
 
   // function to open delete post option
   const handleOpen = () => {
@@ -491,9 +492,11 @@ const Post = ({ post, setCurrentId, fromProfile }) => {
                 onChange={(e) => setCommentMessage(e.target.value)}
               />
               <Button
-                style={{ width: "20%", color: "#ffa500", padding: "0" }}
+                style={{ width: "20%", color: "#ffa500", padding: "0", opacity: commented ? "0.4" : "1" }}
+                disabled={commented}
                 onClick={() => {
                   console.log("Clicked!");
+                  setCommented(true);
                   dispatch(
                     commentPost(post._id, {
                       userID: creatorID,
@@ -501,8 +504,9 @@ const Post = ({ post, setCurrentId, fromProfile }) => {
                     })
                   ).then(() => {
                     setCommentMessage("");
+                    setCommented(false);
                     console.log("Done");
-                  });
+                  }).catch((err) => setCommented(false));
                 }}
               >
                 <SendIcon />


### PR DESCRIPTION
Issue #185 
I have solved the issue of multiple commenting.
Now the user can comment only one at a time till the comment is either successful or failed.
I have disabled the button while comment process is going. Also have added some opacity so that user may know that you cannot comment again right now.

Some screenshots to get a understanding of the work.

Before Commenting
![Screenshot from 2021-04-09 14-43-12](https://user-images.githubusercontent.com/66305085/114158752-b0eac800-9942-11eb-97b9-3b0d3cca573b.png)
Commenting process going on
![Screenshot from 2021-04-09 14-43-24](https://user-images.githubusercontent.com/66305085/114158761-b34d2200-9942-11eb-8faa-f5d889b3658e.png)
After Completion
![Screenshot from 2021-04-09 14-43-01](https://user-images.githubusercontent.com/66305085/114158748-af210480-9942-11eb-948b-e20734bee221.png)
