### PR TITLE
Fixed bug - user could not delete their own comment

### DIFF
--- a/client/src/components/Posts/Post/Post.js
+++ b/client/src/components/Posts/Post/Post.js
@@ -92,7 +92,7 @@ const Post = ({ post, setCurrentId, fromProfile }) => {
   const handleCommentOpen = (comment) => {
     console.log(comment);
     console.log(creatorID);
-    if (comment.postedBy == creatorID) {
+    if (comment._id == creatorID) {
       console.log(true);
       setOpenDeleteComment(true);
     } else {


### PR DESCRIPTION
Closes #178 

A user can now delete their own comments on others' posts, without needing admin access.