### PR TITLE
Form accepts only image

### DIFF
--- a/client/src/components/Form/Form.js
+++ b/client/src/components/Form/Form.js
@@ -206,9 +206,14 @@ const Form = ({ currentId, setCurrentId }) => {
               <FileBase
                 type="file"
                 multiple={false}
-                onDone={({ base64 }) => {
-                  setPostData({ ...postData, selectedFile: base64 });
-                  setError();
+                onDone={({ base64, file }) => {
+                  if (file.type.includes("image")) {
+                    setPostData({ ...postData, selectedFile: base64 });
+                    setError();
+                  } else {
+                    setPostData({ ...postData, selectedFile: "" });
+                    setError("Only Image can be uploaded");
+                  }
                 }}
               />
             </div>


### PR DESCRIPTION
Issue: #195 

Now the input will only allow images to get uploaded.
If other extensions files are uploaded, it doesn't uploads and gives the error or only images can be uploaded.

Screenshot of error:
![Screenshot from 2021-04-11 01-22-40](https://user-images.githubusercontent.com/66305085/114282976-ea1b5900-9a64-11eb-9127-b33966921339.png)
