### PR TITLE
Profile photo coming from different api

### DIFF
--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -143,6 +143,12 @@ export const getProfileById = (id) =>
     },
   });
 
+export const getProfilePhotoById = (id) =>
+  axios({
+    method: "get",
+    url: `${userUrl}/get-profile-photo-by-id/${id}`,
+  });
+
 export const updateProfileById = (id, body) =>
   axios({
     method: "put",

--- a/client/src/components/Profile/Profile.js
+++ b/client/src/components/Profile/Profile.js
@@ -11,6 +11,7 @@ import {Button, CircularProgress} from '@material-ui/core';
 import * as api from '../../api/index';
 import FileBase from 'react-file-base64';
 import { toast } from 'react-toastify';
+import noProfilePhoto from "../../assets/noProfilePhoto.jpg";
 import * as validator from '../../utils/validator';
 import moment from 'moment';
 
@@ -27,12 +28,12 @@ function Profile() {
     const [name ,setName] = useState("");
     const [email, setEmail] = useState("");
     const [bio, setBio] = useState("");
-    const [img, setImg] = useState("");
+    const [img, setImg] = useState(noProfilePhoto);
     const [joined, setJoined] = useState("");
 
     const [newName, setNewName] = useState("");
     const [newBio, setNewBio] = useState("");
-    const [newProfile, setNewProfile] = useState("");
+    const [newProfile, setNewProfile] = useState(noProfilePhoto);
 
     useEffect(async () => {
         setLoading(true);
@@ -44,20 +45,28 @@ function Profile() {
 
             const response = await api.getProfileById(data.id);
             // console.log(response.data);
-            const {name, email, bio, createdOn, img} = response.data.user;
+            const {name, email, bio, createdOn} = response.data.user;
             // console.log(name, email, bio, createdOn, img);
 
             setName(name);
             setEmail(email);
             setBio(bio);
             setJoined(createdOn);
-            setImg(img);
             setId(data.id);
             setNewName(name);
             setNewBio(bio);
+
+            setLoading(false);
+        
+            const imgResponse = await api.getProfilePhotoById(data.id);
+            console.log(imgResponse);
+            const { img } = imgResponse.data;
+
+            setImg(img);
             setNewProfile(img);
 
         } catch (error) {
+            setLoading(false);
             // console.log(error);
             if(error.response) {
                 toast.error(error.response.data.message);
@@ -71,8 +80,6 @@ function Profile() {
             history.push('/');
 
         }
-
-        setLoading(false);
         // console.log(posts);
     }, []);
 

--- a/server/controller/authentication.js
+++ b/server/controller/authentication.js
@@ -241,7 +241,7 @@ export const getProfileById = async (req, res) => {
         const user = await User.findOne({_id: id});
         delete user._doc.password;
         delete user._doc.resetPassLink;
-
+        delete user._doc.img;
         return res.status(200).json({message: "User returned.", user});
     }
     catch (error) {
@@ -249,6 +249,20 @@ export const getProfileById = async (req, res) => {
     }
 }
 
+export const getProfilePhoto = async (req, res) => {
+    try {
+        const id = req.params.id;
+        const user = await User.findOne({ _id: id });
+        delete user._doc.password;
+        delete user._doc.resetPassLink;
+        const img = user._doc.img
+        return res.status(200).json({message: "Profile Image returned.", img});        
+    } catch (error) {
+        return res.status(404).json({message: error.message});
+    }
+    
+  };
+  
 export const updateProfileById = async (req, res) => {
     try {
         const id = req.params.id;

--- a/server/routes/authentication.js
+++ b/server/routes/authentication.js
@@ -13,6 +13,7 @@ import {
   getProfileById,
   sendOtp,
   verifyOtp,
+  getProfilePhoto,
 } from "../controller/authentication.js";
 
 import requireLogin from "../middleware/loginRequired.js";
@@ -30,6 +31,7 @@ router.put("/forgot", forgot);
 router.put("/reset-password", resetPassword);
 
 router.get("/get-profile-by-id/:id", requireLogin, getProfileById);
+router.get("/get-profile-photo-by-id/:id", getProfilePhoto);
 router.put("/update-profile-by-id/:id", requireLogin, updateProfileById);
 
 export default router;


### PR DESCRIPTION
Issue: #228 

Initially the photo and other details were coming from same api. Hence the user has to wait for whole data to be get loaded.
Now the issue is solved by not sending the image in the api of getting user profile data and instead sending it through another api having only image.
This will let the page get loaded first. The data can be visible.
After the data loads, within few seconds later, the image comes from back and gets loaded. This removes the drawback of letting user to wait for whole data to see rather than seeing data first and then image.

Data received without image.
Here data is loaded and user can see the page.
Note: Image is coming at backside.
![Screenshot from 2021-05-21 23-18-34](https://user-images.githubusercontent.com/66305085/119178908-edeec200-ba8b-11eb-9c78-45c0a292f414.png)

Within few seconds, the image also loads.
![Screenshot from 2021-05-21 23-18-49](https://user-images.githubusercontent.com/66305085/119178952-f9da8400-ba8b-11eb-9c36-fd078ec5652c.png)
