### PR TITLE
Content is now not hidden due to the drawer

### DIFF
--- a/client/src/components/Footer/Footer.js
+++ b/client/src/components/Footer/Footer.js
@@ -18,7 +18,7 @@ function Footer() {
             <div
               class="col-lg-12 col-md-12 col-sm-12"
               align="left"
-              style={{ paddingLeft: "5%", marginTop: "0%", marginBottom: "0%" }}
+              style={{ marginTop: "0%", marginBottom: "0%" }}
             >
               <h1
                 class="text-uppercase"

--- a/client/src/components/Footer/style.css
+++ b/client/src/components/Footer/style.css
@@ -7,3 +7,13 @@
     width: 100%
   
   }
+
+.footer-row div {
+    padding-left: 240px ;
+  }
+
+@media only screen and (max-width: 600px) {
+  .footer-row div {
+    padding-left: 0px ;
+  } 
+  }


### PR DESCRIPTION
Issue: #259 
Now, the content is at center. Also if decreasing the width of the screen, the content doesn't hides.
![Screenshot from 2021-05-29 00-55-01](https://user-images.githubusercontent.com/66305085/120033579-5e13bf80-c019-11eb-8fe4-3636b8b3bf21.png)
![Screenshot from 2021-05-29 00-55-16](https://user-images.githubusercontent.com/66305085/120033586-5fdd8300-c019-11eb-8285-de3ff7b43c24.png)
