### PR TITLE
Added 3 feature

### DIFF
--- a/client/src/components/Posts/Post/Post.js
+++ b/client/src/components/Posts/Post/Post.js
@@ -99,6 +99,7 @@ const Post = ({ post, setCurrentId, fromProfile, setOpenCreatePost }) => {
   const [commentID, setCommentID] = useState('');
   const [commented, setCommented] = useState(false);
   const [commentDeleted, setCommentDeleted] = useState(false);
+  const [postDeleted, setPostDeleted] = useState(false);
 
   // function to open delete post option
   const handleOpen = () => {
@@ -148,6 +149,11 @@ const Post = ({ post, setCurrentId, fromProfile, setOpenCreatePost }) => {
       if (openDelete) {
         // for user
         let matched = false;
+        setPostDeleted(true);
+        if (!password) {
+          setPostDeleted(false)
+          return toast.error("Passowrd Cannot be Empty");
+        }
         try {
           const { data } = await api.checkPassword({
             id: creatorID,
@@ -163,9 +169,11 @@ const Post = ({ post, setCurrentId, fromProfile, setOpenCreatePost }) => {
             toast.success("Post Deleted.")
           );
           handleClose();
+          setPostDeleted(false);
           toast.info("Deleting Post... It may take some seconds.");
         } else {
           setOpenDelete(false);
+          setPostDeleted(false);
           toast.error("You have entered wrong password!");
         }
       } else if (openDeleteAdmin) {
@@ -175,9 +183,11 @@ const Post = ({ post, setCurrentId, fromProfile, setOpenCreatePost }) => {
             toast.success("Post Deleted.")
           );
           handleClose();
+          setPostDeleted(false);
           toast.info("Deleting Post... It may take some seconds.");
         } else {
           setOpenDeleteAdmin(false);
+          setPostDeleted(false);
           toast.error("You have entered wrong password!!!");
         }
       }
@@ -185,6 +195,7 @@ const Post = ({ post, setCurrentId, fromProfile, setOpenCreatePost }) => {
 
     return (
       <div className={classes.paper} >
+        <CloseIcon onClick={handleClose} style={{ fontSize: "2em", position: "absolute", right: "5px", top: "5px", cursor: "pointer" }}/>
         <h2 id="simple-modal-title">
           <center>Please Enter {name} Password</center>
         </h2>
@@ -203,6 +214,10 @@ const Post = ({ post, setCurrentId, fromProfile, setOpenCreatePost }) => {
           variant="contained"
           className={classes.paperButton}
           onClick={handleSubmit}
+          disabled={postDeleted}
+          style={{
+            opacity: postDeleted ? "0.8" : "1"
+          }}
         >
           Submit
         </Button>


### PR DESCRIPTION
Closes #267 

Changes made are as follows:
1. Now, after clicking on submit, only one post gets deleted. 
2. Only once the error shows
3. Empty password cannot be put by the user. And if submits empty, then api call doesn't goes, either a toast notification is shown.
4. Close icon for that modal which was left from previous PR.

![Screenshot from 2021-05-31 00-35-45](https://user-images.githubusercontent.com/66305085/120117154-7a466680-c1a9-11eb-9e7c-42fbb009f716.png)
![Screenshot from 2021-05-31 00-40-18](https://user-images.githubusercontent.com/66305085/120117159-7ca8c080-c1a9-11eb-8432-bac2e7d30cf7.png)
