### PR TITLE
Long Content is now handled

### DIFF
--- a/client/src/components/Posts/Post/Post.js
+++ b/client/src/components/Posts/Post/Post.js
@@ -322,6 +322,20 @@ const Post = ({ post, setCurrentId, fromProfile, setOpenCreatePost }) => {
 
   const [commentMessage, setCommentMessage] = useState("");
 
+  const showTitle = (post) => {
+    if (contentToggle) {
+      if ((post.title.length >= 35)) 
+      {
+        return `${post.title.substring(0,35)}...`;
+      }
+      else 
+      {
+        return post.title;
+      }
+    }
+
+    return post.title;
+  }
   return (
     <>
       <Card data-aos="fade-up"  className={classes.card}>
@@ -397,8 +411,8 @@ const Post = ({ post, setCurrentId, fromProfile, setOpenCreatePost }) => {
         </div>
 
         {/* ----- Post's Title ----- */}
-        <Typography className={classes.title} variant="h5" gutterBottom>
-          {post.title}
+        <Typography className={classes.title} variant="h5" gutterBottom title={post.title}>
+          {showTitle(post)}
         </Typography>
 
         {/* ----- Post's text content ----- */}

--- a/client/src/components/Posts/style.js
+++ b/client/src/components/Posts/style.js
@@ -3,7 +3,7 @@ import { makeStyles } from '@material-ui/core/styles';
 export default makeStyles((theme) => ({
   mainContainer: {
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'baseline',
   },
   smMargin: {
     margin: theme.spacing(1),


### PR DESCRIPTION
Closes #279 
Now, if long content is put, then it can handle it.

If title is long of more than 35 characters, then it shows first 35 characters and then 3 dots (...) explaining that the further there is more content. And once the read more button is clicked, then the content is shown. And if again the read less is clicked, the content again shows first 35 char and 3 dots.

Here is the implementation photos.
![Screenshot from 2021-05-31 19-14-03](https://user-images.githubusercontent.com/66305085/120203526-6d775080-c245-11eb-9935-c17c7452f6d3.png)
![Screenshot from 2021-05-31 19-14-32](https://user-images.githubusercontent.com/66305085/120203533-6fd9aa80-c245-11eb-9cc5-90b81a8add5a.png)
